### PR TITLE
Two minor tweaks to demo.py and PAGE.py

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -81,7 +81,7 @@ if __name__ == '__main__':
                                                           mode='min_rectangle', n_max_boxes=1)
 
             # Draw page box on original image and export it. Add also box coordinates to the txt file
-            original_img = imread(filename, mode='RGB')
+            original_img = imread(filename, pilmode='RGB')
             if pred_page_coords is not None:
                 cv2.polylines(original_img, [pred_page_coords[:, None, :]], True, (0, 0, 255), thickness=5)
                 # Write corners points into a .txt file

--- a/dh_segment/post_processing/PAGE.py
+++ b/dh_segment/post_processing/PAGE.py
@@ -333,7 +333,7 @@ class Page(BaseElement):
         root = ET.Element('PcGts')
         root.set('xmlns', _ns['p'])
         # Metadata
-        generated_on = str(datetime.datetime.now())
+        generated_on = str(datetime.datetime.now().isoformat())
         metadata = ET.SubElement(root, 'Metadata')
         creator = ET.SubElement(metadata, 'Creator')
         creator.text = creator_name


### PR DESCRIPTION
With imageio version 2.3.0 on my Windows box, the optional 'mode' param on the call to imread in demo.py needs to be 'pilmode'. And in PAGE.py, the call to datetime.now needs to pass into a call to .isoformat in order to generate PAGEgts compliant XML files.