### PR TITLE
via annotation processing

### DIFF
--- a/dh_segment/io/__init__.py
+++ b/dh_segment/io/__init__.py
@@ -63,6 +63,21 @@ PAGE XML and JSON import / export
     PAGE.json_serialize
 
 ----
+
+VGG Image Annotator helpers
+---------------------------
+
+.. autosummary::
+    via.get_annotations
+    via.get_labels
+    via.collect_working_items
+    via.create_masks
+    via.compute_reduced_dimensions
+    via.scale_down_original
+    via.getimage_from_iiif
+
+----
+
 """
 
 
@@ -103,3 +118,5 @@ __all__ = _INPUT  # + _PAGE_OBJECTS + _PAGE_FN
 from .input import *
 from .input_utils import *
 from . import PAGE
+from . import via
+

--- a/dh_segment/io/__init__.py
+++ b/dh_segment/io/__init__.py
@@ -64,18 +64,36 @@ PAGE XML and JSON import / export
 
 ----
 
+.. _ref_via:
+
 VGG Image Annotator helpers
 ---------------------------
+
+
+**VIA objects**
+
+.. autosummary::
+    via.WorkingItem
+    via.VIAttribute
+
+
+**Creating masks with VIA annotations**
 
 .. autosummary::
     via.load_annotation_data
     via.export_annotation_dict
-    via.get_annotations
-    via.get_via_attributes_regions
-    via.get_labels_per_attribute
+    via.get_annotations_per_file
+    via.parse_via_attributes
+    via.get_via_attributes
     via.collect_working_items
-    via.create_masks_v1
-    via.create_masks_v2
+    via.create_masks
+
+
+**Formatting in VIA JSON format**
+
+.. autosummary::
+    via.create_via_region_from_coordinates
+    via.create_via_annotation_single_image
 
 ----
 

--- a/dh_segment/io/__init__.py
+++ b/dh_segment/io/__init__.py
@@ -68,13 +68,14 @@ VGG Image Annotator helpers
 ---------------------------
 
 .. autosummary::
+    via.load_annotation_data
+    via.export_annotation_dict
     via.get_annotations
-    via.get_labels
+    via.get_via_attributes_regions
+    via.get_labels_per_attribute
     via.collect_working_items
-    via.create_masks
-    via.compute_reduced_dimensions
-    via.scale_down_original
-    via.getimage_from_iiif
+    via.create_masks_v1
+    via.create_masks_v2
 
 ----
 

--- a/dh_segment/io/via.py
+++ b/dh_segment/io/via.py
@@ -245,7 +245,7 @@ def get_labels(annotation_file: str) -> dict:
     # list(annotations['_via_attributes']['region'][{name_attributes}][{args}]
     label_list = list(annotations['_via_attributes']['region']['Label']['options'])
 
-    # todo: keep a list of colors and assign randomly to label (to avoid hard coding labels/color correspondance)
+    # todo: keep a list of colors and assign randomly to label (to avoid hard coding labels/color correspondence)
     # todo: or take it from a config file
     label_color = dict()
     for label in label_list:
@@ -259,7 +259,7 @@ def get_labels(annotation_file: str) -> dict:
 
 def get_via_attributes_regions(annotation_dict: dict, via_version: int=2) -> List[str]:
     """
-    Gets the attributes of the annotataed data.
+    Gets the attributes of the annotated data.
 
     :param annotation_dict:
     :param via_version: either 1 or 2 (for VIA v 1.0 or VIA v 2.0)
@@ -371,6 +371,7 @@ def create_masks_v2(masks_dir: str, working_items: List[WorkingItem], annotation
     def resize_and_write_mask(mask_image: np.ndarray, working_item: WorkingItem, label_item: str):
         """
         Resize only if needed (if working_item.reduced != working_item.original)
+
         :param mask_image:
         :param working_item:
         :param label_item:
@@ -469,6 +470,7 @@ def create_masks_v1(masks_dir: str, working_items: List[WorkingItem], collection
     def resize_and_write_mask(mask_image: np.ndarray, working_item: WorkingItem, label_item: str):
         """
         Resize only if needed (if working_item.reduced != working_item.original)
+
         :param mask_image:
         :param working_item:
         :param label_item:
@@ -603,10 +605,13 @@ def create_masks_v1(masks_dir: str, working_items: List[WorkingItem], collection
 #         create_masks_v2(masks_dir, working_items, annotation_file, collection)
 #
 
+# EXPORT
+# ------
 
 def _get_xywh_from_coordinates(coordinates: np.array) -> Tuple[int, int, int, int]:
     """
-    From cooridnates points get x,y, width height
+    From coordinates points get x,y, width, height
+
     :param coordinates: (N,2) coordinates (x,y)
     :return: x, y, w, h
     """
@@ -621,6 +626,7 @@ def _get_xywh_from_coordinates(coordinates: np.array) -> Tuple[int, int, int, in
 
 def create_via_region_from_coordinates(coordinates: np.array, region_attributes: dict, type_region: str) -> dict:
     """
+    Formats coordinates to a VIA region (dict).
 
     :param coordinates: (N, 2) coordinates (x, y)
     :param region_attributes: dictionary with keys : name of labels, values : values of labels
@@ -657,11 +663,12 @@ def create_via_region_from_coordinates(coordinates: np.array, region_attributes:
 def create_via_annotation_single_image(img_filename: str, via_regions: List[dict],
                                        file_attributes: dict=None) -> Dict[str, dict]:
     """
+    Returns a dictionary item {key: annotation} in VIA forat to further export in .json file
 
-    :param img_filename:
-    :param via_regions:
-    :param file_attributes:
-    :return:
+    :param img_filename: path to the image
+    :param via_regions: regions in VIA format (output from ``create_via_region_from_coordinates``)
+    :param file_attributes: file attributes (usually None)
+    :return: dictionary item with key and annotations in VIA format
     """
 
     basename = os.path.basename(img_filename)

--- a/dh_segment/io/via.py
+++ b/dh_segment/io/via.py
@@ -13,10 +13,10 @@ from skimage import transform
 from collections import namedtuple
 from imageio import imsave, imread
 import requests
+from PIL import Image
 from itertools import filterfalse, chain
 from typing import List, Tuple, Dict
 import cv2
-from taputapu.io.image import get_image_shape_without_loading
 
 
 # To define before using the corresponding functions
@@ -156,13 +156,19 @@ def _collect_working_items_from_local_images(via_annotations: dict, images_dir: 
         name_id = re.sub('.png\d*', '.png', name_id)
         return name_id
 
+    def _get_image_shape_without_loading(filename: str) -> Tuple[int, int]:
+        image = Image.open(filename)
+        shape = image.size
+        image.close()
+        return shape
+
     working_items = list()
 
     for key, v in tqdm(via_annotations.items()):
         filename = _formatting(key)
 
         absolute_filename = os.path.join(images_dir, filename)
-        shape_image = get_image_shape_without_loading(absolute_filename)
+        shape_image = _get_image_shape_without_loading(absolute_filename)
 
         regions = v['regions']
 

--- a/dh_segment/utils/via.py
+++ b/dh_segment/utils/via.py
@@ -10,7 +10,7 @@ Script with CLI to process annotation data produced with VGG Image Annotation (V
 
 
 Usage:
-    create_masks.py --task=<t> --collection=<c> --config-file=<cf>
+    via.py --task=<t> --collection=<c> --config-file=<cf>
 
 Options:
     --collection<collection> document collection to work with

--- a/dh_segment/utils/via.py
+++ b/dh_segment/utils/via.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python
+# coding: utf-8 
+
+"""
+Script with CLI to process annotation data produced with VGG Image Annotation (VIA) tool:
+- scale down original images
+- parse VIA annotation (json)
+- create images with masks
+(cf. http://www.robots.ox.ac.uk/~vgg/software/via/; done on VIA 2.0.0)
+
+
+Usage:
+    create_masks.py --task=<t> --collection=<c> --config-file=<cf>
+
+Options:
+    --collection<collection> document collection to work with
+    --task=<t> task to do: 'original' to downscale original images or 'masks' to create masks.
+    --config-file=<cf>  configuration file
+
+"""
+
+
+import docopt
+import json
+import sys
+import os
+from tqdm import tqdm
+import numpy as np
+from skimage import transform
+from collections import namedtuple
+from imageio import imsave, imread
+import logging
+import requests
+from requests.auth import HTTPBasicAuth
+
+from dask.diagnostics import ProgressBar
+import dask.bag as db
+
+
+__author__ = "maudehrmann"
+
+iiif_password = os.environ["IIIF_PWD"]
+
+logger = logging.getLogger(__name__)
+
+WorkingItem = namedtuple(  # TODO:
+    "WorkingItem", [
+        'collection',
+        'image_name',
+        'original_x',
+        'original_y',
+        'reduced_x',
+        'reduced_y',
+        'iiif',
+        'annotations'
+    ]
+)
+
+
+def init_logger(logger, log_level, log_file):
+    """Initialise the logger."""
+    logger.setLevel(log_level)
+
+    formatter = logging.Formatter(
+        '%(asctime)s %(name)-12s %(levelname)-8s %(message)s'
+    )
+
+    if log_file is not None:
+        fh = logging.FileHandler(filename=log_file, mode='w')
+        fh.setFormatter(formatter)
+        logger.addHandler(fh)
+
+    ch = logging.StreamHandler(sys.stdout)
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+
+    logger.info("Logger successfully initialised")
+
+    return logger
+
+
+def get_annotations(annotations_dict, iiif_url):
+    """
+    From VIA json file, get annotations relative to the given `iiif_url`.
+    :param annotations_dict: VIA annotation output (originally json)
+    :param iiif_url: the file to look for
+    :return: dict
+    """
+    k = iiif_url + "-1"
+    if k in annotations_dict['_via_img_metadata']:
+        myannotation = annotations_dict['_via_img_metadata'][k]
+        if iiif_url == myannotation['filename']:
+            return myannotation['regions']
+        else:
+            return None
+
+
+def compute_reduced_dimensions(x, y):
+    """
+    Compute new dimensions with height set to 2000.
+    :param x: height
+    :param y: width
+    :return: tuple
+    """
+    ratio = y / x
+    target_h = 2000
+    target_w = int(target_h*ratio)
+    return target_h, target_w
+
+
+def collect_working_items(image_url_file, annotation_file, collection):
+    """
+    Given VIA annotation input, collect all info on `WorkingItem` object.
+    :param image_url_file: file listing IIIF URLs files
+    :param annotation_file: VIA json file, output of manual annotation
+    :param collection: target collection to consider
+    :return: list of `WorkingItem`
+    """
+    logger.info(f"Collecting working items for {collection}")
+    working_items = []
+    session = requests.Session()
+
+    # load manual annotation json data
+    with open(annotation_file, 'r') as a:
+        annotations = json.load(a)
+
+    # iterate over image IIIF URLs and build working items
+    with open(image_url_file) as current_file:
+        lines = current_file.readlines()
+        for line in tqdm(lines, desc='URL2WorkingItem'):
+            x = None
+            y = None
+            target_h = None
+            target_w = None
+
+            # line is e.g. 'https://myserver.ch/iiif_project/image-name/full/full/0/default.jpg'
+            basename = "https://myserver.ch/iiif_project/"  # todo: update, or even pass as param
+            iiif = line.strip("\n")
+
+            # get image-name
+            image_name = line.split(basename)[1].split("/full/full/0/default.jpg")[0]
+
+            # get image dimensions
+            iiif_json = iiif.replace("default.jpg", "info.json")
+            resp_image = session.get(iiif, auth=('epfl-team', iiif_password))  # need to request image first
+            resp_json = session.get(iiif_json, auth=('epfl-team', iiif_password))
+            if resp_json.status_code == requests.codes.ok:
+                x = resp_json.json()['height']
+                y = resp_json.json()['width']
+                target_h, target_w = compute_reduced_dimensions(x, y)
+            else:
+                resp_json.raise_for_status()
+
+            regions = get_annotations(annotations, iiif)
+
+            wk_item = WorkingItem(
+                collection,
+                image_name,
+                x,
+                y,
+                target_h,
+                target_w,
+                iiif,
+                regions
+            )
+            working_items.append(wk_item)
+
+    logger.info(f"Collected {len(working_items)} items.")
+    return working_items
+
+
+def scale_down_original(working_item, img_out_dir):
+    """
+    Copy and reduce original image files
+    :param img_out_dir: where to put the downscaled images.
+    :param working_items: dict of `WorkingItems`
+    :return: None
+    """
+    image_set_dir = os.path.join(img_out_dir, working_item.collection, "images")
+    if not os.path.exists(image_set_dir):
+        try:
+            os.makedirs(image_set_dir)
+        except OSError as e:
+            if e.errno != os.errno.EEXIST:
+                raise
+            pass
+
+    outfile = os.path.join(image_set_dir, working_item.image_name + "_ds.png")
+    if not os.path.isfile(outfile):
+        img = getimage_from_iiif(working_item.iiif, 'epfl-team', iiif_password)
+        img_resized = transform.resize(
+                                img,
+                                [working_item.reduced_x, working_item.reduced_y],
+                                anti_aliasing=False,
+                                preserve_range=True
+        )
+        imsave(outfile, img_resized.astype(np.uint8))
+
+
+def getimage_from_iiif(url, user, pwd):
+    img = requests.get(url, auth=(user, pwd))
+    return imread(img.content)
+
+
+def write_mask(mask, masks_dir, collection, image_name, label):
+    """ Save a mask with filename containing 'label' """
+    outdir = os.path.join(masks_dir, collection, image_name)
+    if not os.path.exists(outdir):
+        os.makedirs(outdir)
+    label = label.strip(' \n').replace(" ", "_").lower() if label is not None else 'nolabel'
+    outfile = os.path.join(outdir, image_name + "-mask-" + label + ".png")
+    #if not os.path.isfile(outfile):
+    imsave(outfile, mask.astype(np.uint8))
+
+
+def get_labels(annotation_file):
+    """
+     Get labels from annotation tool (VIA) settings
+    :param annotation_file: manual annotation json file
+    :return:  dict (k=label, v=RGB code)
+    """
+    with open(annotation_file, 'r') as a:
+        annotations = json.load(a)
+
+    label_list = list(annotations['_via_attributes']['region']['Label']['options'])
+
+    # todo: keep a list of colors and assign randomly to label (to avoid hard coding labels/color correspondance)
+    # todo: or take it from a config file
+    label_color = dict()
+    for label in label_list:
+        if label == "MYLABEL1":
+            label_color[label] = (255, 255, 255)  # white
+        elif label == "MYLABEL2":
+            label_color[label] = (255, 255, 0)  # yellow
+        # etc.
+    return label_color
+
+
+def create_masks(masks_dir, working_items, annotation_file, collection):
+    """
+    For each annotation, create a corresponding binary mask and resize it (h = 2000).
+    Several annotations of the same class on the same image produce one image with several masks.
+    :param masks_dir: where to output the masks
+    :param working_items: infos to work with
+    :param annotation_file:
+    :return: None
+    """
+    logger.info(f"Creating masks in {masks_dir}...")
+
+    annotation_summary = dict()
+
+    for wi in tqdm(working_items, desc="workingItem2mask"):
+        labels = []
+        label_list = get_labels(annotation_file)
+        # the image has no annotation, writing a black mask:
+        if not wi.annotations:
+            mask = np.zeros([wi.original_x, wi.original_y], np.uint8)
+            mask_resized = transform.resize(mask, [wi.reduced_x, wi.reduced_y], anti_aliasing=False,
+                                            preserve_range=True, order=0)
+            write_mask(mask_resized, masks_dir, collection, wi.image_name, None)
+            labels.append("nolabel")
+        # check all possible labels for the image and create mask:
+        else:
+            for label in label_list.keys():
+                # get annotation corresponding to current label
+                selected_regions = list(filter(lambda r: r['region_attributes']['Label'] == label, wi.annotations))
+                if selected_regions:
+                    # create a 0 matrix (black background)
+                    mask = np.zeros([wi.original_x, wi.original_y], np.uint8)
+                    # add one or several mask for current label
+                    # nb: if 2 labels are on the same page, they belongs to the same mask
+                    for sr in selected_regions:
+                        x = sr['shape_attributes']['x']
+                        y = sr['shape_attributes']['y']
+                        w = sr['shape_attributes']['width']
+                        h = sr['shape_attributes']['height']
+                        # project region(s) on the mask (binary b/w)
+                        mask[y:y + h, x:x + w] = 255
+
+                    # resize
+                    mask_resized = transform.resize(mask, [wi.reduced_x, wi.reduced_y], anti_aliasing=False,
+                                                    preserve_range=True, order=0)
+                    # write
+                    write_mask(mask_resized, masks_dir, collection, wi.image_name, label)
+                    # add to existing labels
+                    labels.append(label.strip(' \n').replace(" ", "_").lower())
+
+        # write summary: list of existing labels per image
+        annotation_summary[wi.image_name] = labels
+        outfile = os.path.join(masks_dir, collection, collection + "-classes.txt")
+        fh = open(outfile, 'w')
+        for a in annotation_summary:
+            fh.write(a + "\t" + str(annotation_summary[a]) + "\n")
+        fh.close()
+
+    logger.info("Done.")
+    return annotation_summary
+
+
+def main(args):
+
+    # logger
+    global logger
+    init_logger(logger, logging.INFO, log_file=None)
+
+    # read config
+    config_file = args["--config-file"]
+    task = args["--task"]
+    collection = args["--collection"]
+
+    if config_file and os.path.isfile(config_file):
+        logger.info(f"Found config file: {os.path.realpath(config_file)}")
+        with open(config_file, 'r') as f:
+            config = json.load(f)
+    else:
+        logging.info("Provide a config file")
+
+    annotation_file = config.get("annotation_file")  # manual annotation json file
+    image_url_file = config.get("image_url_file")  # url image list
+    experiments_dir = config.get("experiments_dir")  # output expe
+    masks_dir = config.get("masks_dir")  # output annotation_objects
+    img_out_dir = config.get("img_out_dir")  # re-scaled images
+
+    logger.info(f"\nGot the following paths:\n"
+                f"annotation_file: {annotation_file}\n"
+                f"image_url_file: {image_url_file}\n"
+                f"experiments_dir: {experiments_dir}\n"
+                f"masks_dir: {masks_dir}\n"
+                f"img_out_dir: {img_out_dir}\n"
+                )
+
+    # to test working items loading
+    if task == "test-collect":
+        collect_working_items(image_url_file, annotation_file, collection)
+
+    # scale down and write original images
+    elif task == "original":
+        working_items = collect_working_items(image_url_file, annotation_file, collection)
+        wi_bag = db.from_sequence(working_items, partition_size=100)
+        wi_bag2 = wi_bag.map(scale_down_original, img_out_dir=img_out_dir)
+        with ProgressBar():
+            wi_bag2.compute()
+
+    # create masks
+    elif task == "masks":
+        working_items = collect_working_items(image_url_file, annotation_file, collection)
+        create_masks(masks_dir, working_items, annotation_file, collection)
+
+
+if __name__ == "__main__":
+    arguments = docopt.docopt(__doc__)
+    main(arguments)

--- a/doc/reference/io.rst
+++ b/doc/reference/io.rst
@@ -76,3 +76,8 @@ Input / Output
 .. automodule:: dh_segment.io.PAGE
     :members:
     :undoc-members:
+
+.. automodule:: dh_segment.io.via
+    :members:
+    :undoc-members:
+    :exclude-members: main, init_logger

--- a/doc/start/annotating.rst
+++ b/doc/start/annotating.rst
@@ -1,0 +1,23 @@
+Creating groundtruth data
+-------------------------
+
+Using GIMP or Photoshop
+^^^^^^^^^^^^^^^^^^^^^^^
+Create directly your masks using your favorite image editor. You just have to draw the regions you want to extract
+with a different color for each label.
+
+Using VGG Image Annotator (VIA)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`VGG Image Annotator (VIA) <http://www.robots.ox.ac.uk/~vgg/software/via/>`_ is an image annotation tool that can be
+used to define regions in an image and create textual descriptions of those regions. You can either use it
+`online <http://www.robots.ox.ac.uk/~vgg/software/via/via.html>`_ or
+`download the application <http://www.robots.ox.ac.uk/~vgg/software/via/downloads/via-2.0.5.zip>`_.
+
+From the exported annotations (in JSON format), you'll have to generate the corresponding image masks.
+See the :ref:`ref_via` in the ``via`` module.
+
+When assigning attributes to your annotated regions, you should favour attributes of type "dropdown", "checkbox"
+and "radio" and avoid "text" type in order to ease the parsing of the exported file (avoid typos and formatting errors).
+
+
+

--- a/doc/start/index.rst
+++ b/doc/start/index.rst
@@ -3,5 +3,6 @@ Quickstart
 
 .. toctree::
     install
+    annotating
     training
     demo

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - setuptools=39.1.0
   - shapely=1.6.4
   - tqdm=4.23.3
+  - requests=2.21.0
   - pip:
     - better-exceptions==0.2.1
     - sacred==0.7.3
@@ -21,5 +22,3 @@ dependencies:
     - sphinx-autodoc-typehints==1.3.0
     - sphinx-rtd-theme==0.4.1
     - sphinxcontrib-bibtex==0.4.0
-    - "--editable=git+https://github.com/solivr/taputapu.git@master#egg=taputapu"
-

--- a/environment.yml
+++ b/environment.yml
@@ -21,4 +21,5 @@ dependencies:
     - sphinx-autodoc-typehints==1.3.0
     - sphinx-rtd-theme==0.4.1
     - sphinxcontrib-bibtex==0.4.0
+    - "--editable=git+https://github.com/solivr/taputapu.git@master#egg=taputapu"
 

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,7 @@ setup(name='dh_segment',
         'scikit-learn',
         'opencv-python',
         'tqdm',
-        'taputapu'
-      ],
-      dependency_links=[
-        'git+ssh://git@github.com/solivr/taputapu.git#egg=taputapu'
+        'requests==2.21.0',
       ],
       extras_require={
           'doc': [

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,10 @@ setup(name='dh_segment',
         'scikit-learn',
         'opencv-python',
         'tqdm',
+        'taputapu'
+      ],
+      dependency_links=[
+        'git+ssh://git@github.com/solivr/taputapu.git#egg=taputapu'
       ],
       extras_require={
           'doc': [


### PR DESCRIPTION
@solivr Hello, here the script with CLI to process annotation data produced with VGG Image Annotation (VIA) tool:
- scale down original images
- parse VIA annotation (json)
- create images with masks
(cf. http://www.robots.ox.ac.uk/~vgg/software/via/; done on VIA 2.0.0)

To be updated according to more generic `dhSegment` needs.

Usage:
    `via.py --task=<t> --collection=<c> --config-file=<cf>`

Options:
```
    --collection<collection> document collection to work with
    --task=<t> task to do: 'original' to downscale original images or 'masks' to create masks.
    --config-file=<cf>  configuration file
```