### PR TITLE
Correcting typo in masks creation script (annotating)

### DIFF
--- a/doc/start/annotating.rst
+++ b/doc/start/annotating.rst
@@ -48,5 +48,5 @@ and "radio" and avoid "text" type in order to ease the parsing of the exported f
         list_attributes = via.get_via_attributes(via_annotations)
 
     # Create one mask per option per attribute
-    via.create_masks(masks_dir, working_items, via_attributes, collection)
+    via.create_masks(masks_dir, working_items, list_attributes, collection)
 


### PR DESCRIPTION
I suggest this correction of what I think is a typo in the calling of the variable `list_attributes` (in stead of `via_attributes` which at this point in the script does not exist) in the example of a mask creation script displayed in the documentation. 