### PR TITLE
Fixing instruction

### DIFF
--- a/doc/start/demo.rst
+++ b/doc/start/demo.rst
@@ -16,7 +16,7 @@ In order to limit memory usage, the images in the dataset we provide have been d
     git clone https://github.com/dhlab-epfl/dhSegment.git
 
 1. Get the annotated dataset `here`_, which already contains the folders ``images`` and ``labels``
-for training, validation and testing set. Unzip it into ``model/pages``. ::
+for training, validation and testing set. Unzip it into ``demo/pages``. ::
 
     cd demo/
     wget https://github.com/dhlab-epfl/dhSegment/releases/download/v0.2/pages.zip


### PR DESCRIPTION
Hello,

I am suggesting this small correction on the instructions to make it match the commands. I believe this is more correct, since there is no `model` directory in the repository at this point and since the commands suggest the unzipping is rather in the `demo/` directory. 