### PR TITLE
Fix cv2.findContours error

### DIFF
--- a/dh_segment/post_processing/boxes_detection.py
+++ b/dh_segment/post_processing/boxes_detection.py
@@ -25,7 +25,7 @@ def find_boxes(boxes_mask: np.ndarray, mode: str= 'min_rectangle', min_area: flo
     assert len(boxes_mask.shape) == 2, \
         'Input mask must be a 2D array ! Mask is now of shape {}'.format(boxes_mask.shape)
 
-    contours, _ = cv2.findContours(boxes_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    _, contours, _ = cv2.findContours(boxes_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
     if contours is None:
         print('No contour found')
         return None


### PR DESCRIPTION
Reference: https://stackoverflow.com/a/25510061/10692493
Error log: 
```
Traceback (most recent call last):
  File "demo.py", line 84, in <module>
    mode='min_rectangle', n_max_boxes=1)
  File "/<internal_dir>/dhSegment/dh_segment/post_processing/boxes_detection.py", line 28, in find_boxes
    contours, _ = cv2.findContours(boxes_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
ValueError: too many values to unpack (expected 2)
```
OpenCV version:
```
$ python
Python 3.7.3 (default, Mar 27 2019, 16:54:48) 
[Clang 4.0.1 (tags/RELEASE_401/final)] :: Anaconda, Inc. on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import cv2
>>> cv2.__version__
'3.4.2'
```