### PR TITLE
fix n_max_boxes off by one

### DIFF
--- a/dh_segment/post_processing/boxes_detection.py
+++ b/dh_segment/post_processing/boxes_detection.py
@@ -105,4 +105,4 @@ def find_boxes(boxes_mask: np.ndarray,
         else:
             return None
     else:
-        return [fb[0] for i, fb in enumerate(found_boxes) if i <= n_max_boxes]
+        return [fb[0] for i, fb in enumerate(found_boxes) if i < n_max_boxes]


### PR DESCRIPTION
boxes_detection.py find_boxes() method n_max_boxes constraint is off by one: it returns n_max_boxes+1 boxes. It is a simple fix. 
